### PR TITLE
Fix bug: GitHub src not loading in iframe

### DIFF
--- a/logpage.py
+++ b/logpage.py
@@ -416,7 +416,7 @@ def create_test_results(readfile):
                 <body>
                     <h1 style="text-align:center">{status}</h1>
                     <h3 style="text-align:center">
-                        <a href="{baseurl}/tree/gh-pages/records/version_{curr_ver}">Build #{curr_ver}</a>
+                        <a href="{baseurl}/tree/gh-pages/records/version_{curr_ver}" target="_blank">Build #{curr_ver}</a>
                     </h3>
                     <h6 style="text-align:center">
                         <a href="index.html" target="_blank">Go to latest build</a>

--- a/regenerate.py
+++ b/regenerate.py
@@ -356,7 +356,6 @@ def create_sidebar():
     '''
 
     # Add GitHub badge on top of sidebar
-    # TODO: let JS inject badge depending on workflow status requested via API
     template =f'''
         <div class="workflow-status"> 
         </div>
@@ -431,7 +430,7 @@ def create_test_results(readfile):
                 <body>
                     <h1 style="text-align:center">{status}</h1>
                     <h3 style="text-align:center">
-                        <a href="{baseurl}/tree/gh-pages/records/version_{curr_ver}">Build #{curr_ver}</a>
+                        <a href="{baseurl}/tree/gh-pages/records/version_{curr_ver}" target="_blank">Build #{curr_ver}</a>
                     </h3>
                     <h6 style="text-align:center">
                         <a href="index.html" target="_blank">Go to latest build</a>


### PR DESCRIPTION
- Link to `https://github.com/EinsteinToolkit/tests/tree/gh-pages/records/version_x` will now open in a new tab